### PR TITLE
substitute parameters

### DIFF
--- a/log4j2migrator.groovy
+++ b/log4j2migrator.groovy
@@ -4,6 +4,7 @@ cli.with {
     h(longOpt: 'help'  , 'usage information'   , required: false )
     o(longOpt: 'output', 'file to write the output', required: false  , args: 1 )
     d(longOpt: 'debug', 'print debug information', required: false  )
+    i(longOpt: 'interpolate', 'substitue parameters', required: false )
 }
 
 OptionAccessor opt = cli.parse(args)
@@ -26,6 +27,11 @@ if( opt.o ) {
 if( opt.d ) {
     debug = opt.d
 } 
+
+@groovy.transform.Field def interpolate
+if ( opt.i ) {
+  interpolate = opt.i
+}
 
 def extraArguments = opt.arguments()
 if (extraArguments) {
@@ -60,8 +66,14 @@ def parse(properties) {
 	def rootLevel
 	def rootAppenders
 
+        def params=[:]
+
 	properties.each { key, value ->
         value=value.trim()
+                if ( interpolate ) {
+                    value = value.replaceAll(/\$\{(.*?)\}/) { m, k -> params[k] }
+                    params[key]=value
+                }
 		if (debug) { System.err.println "property ${key}=[${value}]" }
 
 		if (key.startsWith("log4j.appender")) {


### PR DESCRIPTION
log4j allows parameter substitution within the properties file.  

The property lines are evaluated from top to bottom.   Hence, the parameter must be defined before substitution.  The interpolated string would be empty if the parameter is not defined. 

Please run the script with -i option to enable this feature.
